### PR TITLE
Remove compass style

### DIFF
--- a/app/styles/vlui-common.scss
+++ b/app/styles/vlui-common.scss
@@ -1,7 +1,3 @@
-@import "compass";
-@import "compass/css3";
-
-
 $pill-radius: 3px;
 $pill-height: 20px;
 $pill-min-width: 150px;
@@ -59,7 +55,7 @@ h4 {
 }
 
 .inline-block {
-  @include inline-block;
+  display: inline-block;
 }
 
 .grow-1{
@@ -112,9 +108,8 @@ h4 {
 
 /* prevent element from being selected http://stackoverflow.com/questions/826782 */
 .noselect {
-  @include user-select(none);
+  user-select: none;
 }
-
 
 /**** FIELD & FIELD-PILLS ****/
 


### PR DESCRIPTION
Remove compass style since
(1) we're already using autoprefixer so there is no point to use both compass mix-ins and auto-prefixer
(2) turn out that I already too much time to setup compass in facetedviz so given (1) this is a corner that we can cut (for now)
