### PR TITLE
debounce in karma to avoid tests running twice.

### DIFF
--- a/gulp/unit-tests.js
+++ b/gulp/unit-tests.js
@@ -25,7 +25,8 @@ function runTests (singleRun, done) {
   gulp.src(testFiles)
     .pipe($.karma({
       configFile: 'karma.conf.js',
-      action: (singleRun)? 'run': 'watch'
+      action: (singleRun)? 'run': 'watch',
+      debounceDelay: 1000
     }))
     .on('error', function (err) {
       // Make sure failed tests cause gulp to exit non-zero


### PR DESCRIPTION
Fixes #88

Not super clean but it works so seems good for now.
