### PR TITLE
VlPlot Renderer Swap & Scroll Lock

### DIFF
--- a/src/components/vlplot/vlplot.html
+++ b/src/components/vlplot/vlplot.html
@@ -1,3 +1,11 @@
 <div class="vis" id="vis-{{visId}}"
-  ng-class="{fit: (maxHeight && vgSpec.height <= maxHeight), overflow: (maxHeight && vgSpec.height > maxHeight)}"
+  ng-class="{
+    fit: (maxHeight && vgSpec.height <= maxHeight),
+    overflow: (maxHeight && vgSpec.height > maxHeight),
+    scroll: unlocked || hoverFocus
+  }"
+  ng-mousedown="unlocked=true"
+  ng-mouseup="unlocked=false"
+  ng-mouseover="mouseover()"
+  ng-mouseout="mouseout()"
 ></div>

--- a/src/components/vlplot/vlplot.js
+++ b/src/components/vlplot/vlplot.js
@@ -1,8 +1,17 @@
 'use strict';
 
 angular.module('vleApp')
-  .directive('vlPlot', function(vg) {
+  .directive('vlPlot', function(vg, $timeout) {
     var counter = 0;
+    var MAX_CANVAS_SIZE = 32767, MAX_CANVAS_AREA = 268435456;
+
+    function getRenderer(spec) {
+      // use canvas by default but use svg if the visualization is too big
+      if (spec.width > MAX_CANVAS_SIZE || spec.height > MAX_CANVAS_SIZE || spec.width*spec.height > MAX_CANVAS_AREA) {
+        return 'svg';
+      }
+      return 'canvas';
+    }
 
     return {
       templateUrl: 'components/vlplot/vlplot.html',
@@ -11,8 +20,21 @@ angular.module('vleApp')
         'vgSpec':'=',
         'maxHeight':'='
       },
+      replace: true,
       link: function(scope, element) {
         scope.visId = (counter++);
+        scope.hoverAction = null;
+        scope.mouseover = function() {
+          scope.hoverAction = $timeout(function(){
+            scope.hoverFocus = true;
+          }, 500);
+        };
+
+        scope.mouseout = function() {
+          $timeout.cancel(scope.hoverAction);
+          scope.hoverFocus = scope.unlocked = false;
+        };
+
         var view;
         scope.$watch('vgSpec',function(spec) {
           if (!spec) {
@@ -25,7 +47,7 @@ angular.module('vleApp')
           if (elem) {
             vg.parse.spec(spec, function(chart) {
               view = null;
-              view = chart({el: elem[0], renderer: 'canvas'});
+              view = chart({el: elem[0], renderer: getRenderer(spec)});
               view.update();
               view.on('mouseover', function(event, item) {
                 // TODO: Hanchuan please create tooltip from this


### PR DESCRIPTION
- make vlplot fallback to svg renderer if the visualization is too big
- add `maxHeight` to enable scroll locking (for `facetedviz`)

fixes https://github.com/uwdata/vegalite/issues/195
