### PR TITLE
Fix issue where display area does not take up full height

### DIFF
--- a/src/app/main/main.html
+++ b/src/app/main/main.html
@@ -1,80 +1,78 @@
-<div ng-controller="MainCtrl">
-  <div class="flex-root vflex full-width full-height">
-    <div class="full-width no-shrink">
-      <div class="card no-right-margin no-top-margin">
-        <div class="right flex-root hflex">
-          <div class="controls">
-            <span ng-show="consts.debug">
-              <a ng-href="{{ {encoding:Spec.chart.vlSpec} | reportUrl }}" target="_blank" class="command debug" tooltips tooltip-size="small"
-                tooltip-content="Report an issue">
-                <i class="fa fa-bug"></i>
-              </a>
-              <a class="command debug" ng-click="showDevPanel = !showDevPanel" tooltips
-                tooltip-size="small"
-                tooltip-content="Debug Tool">
-                <i class="fa fa-wrench"></i>
-              </a>
-            </span>
-            <a ng-show="Bookmarks.isSupported" class="command" ng-click="bookmarksShown=true">
-              <i class="fa fa-bookmark"></i>
-              Bookmarks ({{Bookmarks.length}})
+<div ng-controller="MainCtrl" class="flex-root vflex full-width full-height">
+  <div class="full-width no-shrink">
+    <div class="card no-right-margin no-top-margin">
+      <div class="right flex-root hflex">
+        <div class="controls">
+          <span ng-show="consts.debug">
+            <a ng-href="{{ {encoding:Spec.chart.vlSpec} | reportUrl }}" target="_blank" class="command debug" tooltips tooltip-size="small"
+              tooltip-content="Report an issue">
+              <i class="fa fa-bug"></i>
             </a>
-            <a class="command" ng-click="chron.undo()" ng-class="{disabled: !canUndo}"><i class="fa fa-undo"></i> Undo</a>
-            <a class="command" ng-click="chron.redo()" ng-class="{disabled: !canRedo}"><i class="fa fa-repeat"></i> Redo</a>
-          </div>
-
-          <div>
-            <a href="https://idl.cs.washington.edu/" target="_blank" class="logo"></a>
-          </div>
+            <a class="command debug" ng-click="showDevPanel = !showDevPanel" tooltips
+              tooltip-size="small"
+              tooltip-content="Debug Tool">
+              <i class="fa fa-wrench"></i>
+            </a>
+          </span>
+          <a ng-show="Bookmarks.isSupported" class="command" ng-click="bookmarksShown=true">
+            <i class="fa fa-bookmark"></i>
+            Bookmarks ({{Bookmarks.length}})
+          </a>
+          <a class="command" ng-click="chron.undo()" ng-class="{disabled: !canUndo}"><i class="fa fa-undo"></i> Undo</a>
+          <a class="command" ng-click="chron.redo()" ng-class="{disabled: !canRedo}"><i class="fa fa-repeat"></i> Redo</a>
         </div>
-        <h1>Pole✭</h1>
+
+        <div>
+          <a href="https://idl.cs.washington.edu/" target="_blank" class="logo"></a>
+        </div>
       </div>
-      <alert-messages></alert-messages>
+      <h1>Pole✭</h1>
     </div>
-    <div class="hflex full-width main-panel grow-1">
-      <div class="pane data-pane noselect">
-        <div class="card abs-100">
-          <div class="right">
-            <dataset-selector ng-if="!embedded"></dataset-selector>
-          </div>
-          <h2>Data</h2>
-          <schema-list></schema-list>
+    <alert-messages></alert-messages>
+  </div>
+  <div class="hflex full-width main-panel grow-1">
+    <div class="pane data-pane noselect">
+      <div class="card abs-100">
+        <div class="right">
+          <dataset-selector ng-if="!embedded"></dataset-selector>
         </div>
-      </div>
-      <div class="pane encoding-pane">
-        <shelves></shelves>
-      </div>
-
-      <div class="pane vis-pane">
-        <vl-plot-group class="card abs-100 no-right-margin full-vl-plot-group"
-            chart="Spec.chart"
-            show-bookmark="true"
-            show-filter-null="true"
-            show-log="true"
-            show-mark-type="true"
-            show-sort="true"
-            show-transpose="true"
-            config-set="large"
-
-            show-label="true"
-            tooltip="true"
-
-            always-scrollable="true"
-            ></vl-plot-group>
+        <h2>Data</h2>
+        <schema-list></schema-list>
       </div>
     </div>
-    <div class="hflex full-width dev-panel" ng-if="showDevPanel">
-      <div class="pane config-pane">
-        <div class="card scroll-y  abs-100">
-          <configuration-editor></configuration-editor>
-        </div>
+    <div class="pane encoding-pane">
+      <shelves></shelves>
+    </div>
+
+    <div class="pane vis-pane">
+      <vl-plot-group class="card abs-100 no-right-margin full-vl-plot-group"
+          chart="Spec.chart"
+          show-bookmark="true"
+          show-filter-null="true"
+          show-log="true"
+          show-mark-type="true"
+          show-sort="true"
+          show-transpose="true"
+          config-set="large"
+
+          show-label="true"
+          tooltip="true"
+
+          always-scrollable="true"
+          ></vl-plot-group>
+    </div>
+  </div>
+  <div class="hflex full-width dev-panel" ng-if="showDevPanel">
+    <div class="pane config-pane">
+      <div class="card scroll-y  abs-100">
+        <configuration-editor></configuration-editor>
       </div>
-      <div class="pane vl-pane">
-        <vl-spec-editor></vl-spec-editor>
-      </div>
-      <div class="pane vg-pane">
-        <vg-spec-editor></vg-spec-editor>
-      </div>
+    </div>
+    <div class="pane vl-pane">
+      <vl-spec-editor></vl-spec-editor>
+    </div>
+    <div class="pane vg-pane">
+      <vg-spec-editor></vg-spec-editor>
     </div>
   </div>
   <bookmark-list

--- a/src/index.html
+++ b/src/index.html
@@ -25,9 +25,7 @@
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
 
-    <div class="abs-100">
-      <ng-include src="'app/main/main.html'"></ng-include>
-    </div>
+    <div class="abs-100" ng-include="'app/main/main.html'"></div>
 
     <!-- build:js(src) scripts/vendor.js -->
     <!-- bower:js -->


### PR DESCRIPTION
See vega/vega-lite-ui#73; closes #322

This was introduced in dea6557d32c7733d220bd5dfca7bcc62f22b4dc8 while addressing an issue that prevented the bookmarks from closing: the display height issue arose due to the introduction of another layer of nesting that the CSS did not account for.

The same angular hierarchy can be achieved with less DOM nesting, so this commit addresses the overflow by removing unneeded intermediate div nodes.

Note that this did not end up being an issue with vega-lite-ui

This diff includes some indentation changes to main.html, so here is the diff with -w to ignore the whitespace:

```diff
diff --git a/src/app/main/main.html b/src/app/main/main.html
index 2fb43b2..80c0dd2 100644
--- a/src/app/main/main.html
+++ b/src/app/main/main.html
@@ -1,5 +1,4 @@
-<div ng-controller="MainCtrl">
-  <div class="flex-root vflex full-width full-height">
+<div ng-controller="MainCtrl" class="flex-root vflex full-width full-height">
   <div class="full-width no-shrink">
     <div class="card no-right-margin no-top-margin">
       <div class="right flex-root hflex">
@@ -76,7 +75,6 @@
       <vg-spec-editor></vg-spec-editor>
     </div>
   </div>
-  </div>
   <bookmark-list
     ng-if="Bookmarks.isSupported"
     active="bookmarksShown"
diff --git a/src/index.html b/src/index.html
index 185d0ea..4bf19ea 100644
--- a/src/index.html
+++ b/src/index.html
@@ -25,9 +25,7 @@
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->

-    <div class="abs-100">
-      <ng-include src="'app/main/main.html'"></ng-include>
-    </div>
+    <div class="abs-100" ng-include="'app/main/main.html'"></div>

     <!-- build:js(src) scripts/vendor.js -->
     <!-- bower:js -->

```