### PR TITLE
[WIP] Make Polestar works with VL 0.9.3

### DIFF
--- a/src/app/spec/spec.service.js
+++ b/src/app/spec/spec.service.js
@@ -53,7 +53,7 @@ angular.module('polestar')
 
     // takes a partial spec
     Spec.parseSpec = function(newSpec) {
-      Spec.spec = vl.schema.util.merge(Spec.instantiate(), newSpec);
+      Spec.spec = vl.schema.util.mergeDeep(Spec.instantiate(), newSpec);
     };
 
     Spec.instantiate = function() {


### PR DESCRIPTION
- call `vl.schema.util.mergeDeep` instead of the old `merge`

__Don’t merge until we release 0.9.3__