### PR TITLE
Use Bookmarks.list.length

### DIFF
--- a/src/app/main/main.html
+++ b/src/app/main/main.html
@@ -7,7 +7,7 @@
           <div class="controls">
             <a ng-show="Bookmarks.isSupported" class="command" ng-click="showModal('bookmark-list')">
               <i class="fa fa-bookmark"></i>
-              Bookmarks ({{Bookmarks.length}})
+              Bookmarks ({{Bookmarks.list.length}})
             </a>
             <a class="command" ng-click="chron.undo()" ng-class="{disabled: !canUndo}"><i class="fa fa-undo"></i> Undo</a>
             <a class="command" ng-click="chron.redo()" ng-class="{disabled: !canRedo}"><i class="fa fa-repeat"></i> Redo</a>


### PR DESCRIPTION
`Bookmarks` service in vega-lite-ui no longer has `.length`. We read `Bookmarks.list.length` instead.
